### PR TITLE
Allow media query breakpoints to be overridden

### DIFF
--- a/app/assets/javascripts/arctic_admin.js
+++ b/app/assets/javascripts/arctic_admin.js
@@ -3,7 +3,7 @@
 //= require arctic_admin/jquery_validate
 
 $(function() {
-  $('form').each(function() {  
+  $('form').each(function() {
     $(this).validate({
       onfocusout: true
     });
@@ -33,46 +33,42 @@ $(function() {
 
   var animationDone = true;
   $('#utility_nav').click(function (e) {
-    if ($(window).width() < 960) {
-      var position = $(this).position();
-      var tabs = $('#tabs');
-      var width = tabs.width() + 1;
+    var position = $(this).position();
+    var tabs = $('#tabs');
+    var width = tabs.width() + 1;
 
-      if (e.pageX < (position.left + 40)) {
-        if(animationDone == true) {
-          animationDone = false;
-          if (tabs.css('left') == '0px') {
-            tabs.animate({
-              left: "-="+width
-            }, 400, function() {
-              animationDone = true;
-            });
-          } else {
-            tabs.animate({
-              left: "+="+width
-            }, 400, function() {
-              animationDone = true;
-            });
-          }
+    if (e.pageX < (position.left + 40)) {
+      if(animationDone == true) {
+        animationDone = false;
+        if (tabs.css('left') == '0px') {
+          tabs.animate({
+            left: "-="+width
+          }, 400, function() {
+            animationDone = true;
+          });
+        } else {
+          tabs.animate({
+            left: "+="+width
+          }, 400, function() {
+            animationDone = true;
+          });
         }
       }
     }
   });
 
   $('body').click(function (e) {
-    if ($(window).width() < 960) {
-      var tabs = $('#tabs');
-      var width = tabs.width() + 1;
-      if (tabs.css('left') == '0px') {
-        if (e.pageX > width && e.pageY > 60) {
-          if(animationDone == true) {
-            animationDone = false;
-            tabs.animate({
-              left: "-="+width
-            }, 400, function() {
-              animationDone = true;
-            });
-          }
+    var tabs = $('#tabs');
+    var width = tabs.width() + 1;
+    if (tabs.css('left') == '0px') {
+      if (e.pageX > width && e.pageY > 60) {
+        if(animationDone == true) {
+          animationDone = false;
+          tabs.animate({
+            left: "-="+width
+          }, 400, function() {
+            animationDone = true;
+          });
         }
       }
     }

--- a/app/assets/stylesheets/variables/_media_queries.scss
+++ b/app/assets/stylesheets/variables/_media_queries.scss
@@ -1,7 +1,7 @@
-$sm-width: 576px;
-$md-width: 768px;
-$lg-width: 992px;
-$x-lg-width: 1400px;
+$sm-width: 576px !default;
+$md-width: 768px !default;
+$lg-width: 992px !default;
+$x-lg-width: 1400px !default;
 
 // <576px  Extra small
 // ≥576px  Small


### PR DESCRIPTION
Although the css `left` property on `$('#tabs')` is now being set when there's a click on `body` even when the tabs are fixed, the `!important` priority means that this has no effect.