### PR TITLE
Fix zoom hamburger bug

### DIFF
--- a/app/assets/javascripts/arctic_admin/base.js
+++ b/app/assets/javascripts/arctic_admin/base.js
@@ -29,7 +29,7 @@ $(function() {
   $('#utility_nav').click(function (e) {
     var position = $(this).position();
     var tabs = $('#tabs');
-    var width = tabs.width() + 1;
+    var width = tabs[0].getBoundingClientRect().width;
 
     if (e.pageX < (position.left + 40)) {
       if(animationDone == true) {
@@ -53,7 +53,7 @@ $(function() {
 
   $('body').click(function (e) {
     var tabs = $('#tabs');
-    var width = tabs.width() + 1;
+    var width = tabs[0].getBoundingClientRect().width;
     if (tabs.css('left') == '0px') {
       if (e.pageX > width && e.pageY > 60) {
         if(animationDone == true) {


### PR DESCRIPTION
If browser zoom is used, the css left property can be 1px insted of 0px and this causes the nav to progress across the screen instead of retracting. By using `tabs[0].getBoundingClientRect().width` instead of the jquery function `tabs.width()`, the var `width` is consistently set.