### PR TITLE
Add note for removing '//= require active_admin/base'

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ In your `active_admin.js`, include the js file:
 //= require arctic_admin/base
 ```
 
+**Remove the line `//= require active_admin/base`**
+
 ### Customization
 
 For this, you need to use sass to custom the theme.


### PR DESCRIPTION
Without doing this, javascript errors occur on page load since `arctic_admin/base.js` includes `//= require active_admin/base`