### PR TITLE
Import font-awesome differently

### DIFF
--- a/app/assets/stylesheets/arctic_admin/_base.scss
+++ b/app/assets/stylesheets/arctic_admin/_base.scss
@@ -1,4 +1,4 @@
-@import "font-awesome";
+@import "font-awesome.css";
 
 @import "reset";
 @import "fonts";


### PR DESCRIPTION
If importing from `arctic_admin/base` from a sass file, it throws an error that font-awesome is missing: `File to import not found or unreadable: font-awesome`

cc: @cle61 