### PR TITLE
Use flex to move flashes messages before title bar.

### DIFF
--- a/app/assets/stylesheets/arctic_admin/_base.scss
+++ b/app/assets/stylesheets/arctic_admin/_base.scss
@@ -11,6 +11,7 @@
 
 @import "components/components";
 
+@import "layouts/wrapper";
 @import "layouts/header";
 @import "layouts/sidebar";
 @import "layouts/main_content";

--- a/app/assets/stylesheets/arctic_admin/layouts/_wrapper.scss
+++ b/app/assets/stylesheets/arctic_admin/layouts/_wrapper.scss
@@ -1,0 +1,8 @@
+#wrapper {
+  display: flex;
+  flex-direction: column;
+
+  .flashes {
+    order: -1;
+  }
+}


### PR DESCRIPTION
As commented [here](https://github.com/cle61/arctic_admin/commit/48c530c9d5e7bbb4c2d000bdca7292abf8e91e95), flashes messages are shown below title bar. This changes allow to fix it.

Also, this hack allows to fix it without having to monkey patch ActiveAdmin layout. IMHO, flexbox are currently very well supported by browsers, and using it will be less prone to issues that monkey patching ActiveAdmin layout code, directly or through a gem like https://github.com/bys-control/activeadmin_custom_layout.