### PR TITLE
Fix the filter moving towards to the left when resizing screen.

### DIFF
--- a/app/assets/javascripts/arctic_admin/base.js
+++ b/app/assets/javascripts/arctic_admin/base.js
@@ -12,6 +12,7 @@ $(function() {
         $(this).animate({
           right: "-="+width
         }, 600, function() {
+          $(this).removeAttr('style');
           animationFilterDone = true;
         });
       } else {


### PR DESCRIPTION
# It closes https://github.com/cle61/arctic_admin/issues/22

## Problem
The bug comes because every time the filter is opened and then closed, the `style` attribute on `#sidebar` element remains with the corresponding styles specifically with the `right: -230px;` rule that when the screen is resized  it makes the filter to be out of its corresponding range because of the `  @media screen and (min-width: $x-lg-width)` media query on `_filter.scss` file.

That makes that when the evaluation of `if ($(this).css('right') == '0px') {` returns `false` making it to sum values like `-230+270` and as a result a positive value `40` which on every click instead of returning a `0` value that hides the filter, it makes the filter to go towards the left.

## Solution
After hiding the filter by setting the `right: 0px` rule to zero we should remove the `style` attribute from `#sidebar` element so that every time is opened and closed it has no right position.

<img width="624" alt="screen shot 2018-03-10 at 12 28 05" src="https://user-images.githubusercontent.com/13169164/37245620-a9dc3a76-2460-11e8-8dc2-440afa9a4a37.png">

By adding this line in the _animation_ callback the problem is solved:
```js
$(this).removeAttr('style');
```