### PR TITLE
Fix menu and pressing actions on iOS devices

### DIFF
--- a/app/assets/javascripts/arctic_admin/base.js
+++ b/app/assets/javascripts/arctic_admin/base.js
@@ -3,7 +3,7 @@
 //= require active_admin/base
 
 $(function() {
-  $(document).on('click', '#sidebar', function(e) {
+  $(document).on('click touchstart', '#sidebar', function(e) {
     var position = $(this).position();
     var width = $(this).width();
     if (e.pageX < position.left) {
@@ -27,7 +27,7 @@ $(function() {
   });
 
   var animationDone = true;
-  $(document).on('click', '#utility_nav', function(e) {
+  $(document).on('click touchstart', '#utility_nav', function(e) {
     var position = $(this).position();
     var tabs = $('#tabs');
     var width = Math.round(tabs[0].getBoundingClientRect().width);
@@ -52,7 +52,7 @@ $(function() {
     }
   });
 
-  $(document).on('click', 'body', function(e) {
+  $(document).on('click touchstart', 'body', function(e) {
     var tabs = $('#tabs');
     var width = Math.round(tabs[0].getBoundingClientRect().width);
     if (tabs.css('left') == '0px') {


### PR DESCRIPTION
It seems to solve some issues (ex: [#33](https://github.com/cle61/arctic_admin/issues/33)) related to click events on iOS devices.

### Problem
`$(document).on('click', '#utility_nav', function(e) {` click event is not fired on iOS devices

### Solution
`$(document).on('click touchstart', '#utility_nav', function(e) {`touchstart is also added on bind process.