### PR TITLE
Give a higher "height" to the `select[multiple]` input in form.

### DIFF
--- a/app/assets/stylesheets/arctic_admin/pages/_form.scss
+++ b/app/assets/stylesheets/arctic_admin/pages/_form.scss
@@ -60,6 +60,10 @@ body.logged_in {
         height: 30px;
       }
 
+      select[multiple] {
+        height: 100px;
+      }
+
       .fragment {
         margin-right: 10px;
 


### PR DESCRIPTION
When creating new resources and in the form we have `select` inputs like the ones below they both look the same way in the UI even the second has the option `multiple: true` enable.

```ruby
f.input :company, as: :select, collection: Company.all

f.input :product_categories, as: :select, collection: ProductCategory.all, multiple: true
```

> Actual behavior

![screen shot 2018-08-31 at 12 54 56](https://user-images.githubusercontent.com/13169164/44929933-59176980-ad22-11e8-9eb0-2a9cf81cdad4.png)

For a **better user experience** when selecting multiple options from `select` elements, it should be possible to the user to see more than one option at a time. And, by giving a _higher CSS_ `height` property value to `select` elements with `multiple` attribute, we solve the problem.

> Expected behavior

![screen shot 2018-08-31 at 13 06 51](https://user-images.githubusercontent.com/13169164/44929934-59176980-ad22-11e8-88c2-38685d9deeb2.png)